### PR TITLE
fix: Don't unnecessarily regenerate keypair and load it correctly

### DIFF
--- a/src/util/keypair.ts
+++ b/src/util/keypair.ts
@@ -1,15 +1,24 @@
 import fs from 'fs';
 import crypto from 'crypto';
 
-const keys = crypto.generateKeyPairSync('ed25519');
-
-const privateKey = keys.privateKey;
-const publicKey = keys.publicKey;
-
 const privateKeyFile = `${process.cwd()}/privkey.pem`;
-const publicKeyFile = `${process.cwd()}/pubkey.pem`;
 
-if (!fs.existsSync(privateKeyFile)) {
+let privateKey: crypto.KeyObject;
+let publicKey: crypto.KeyObject;
+
+if (fs.existsSync(privateKeyFile)) {
+    privateKey = crypto.createPrivateKey({
+        key: fs.readFileSync(privateKeyFile),
+        format: 'pem',
+    });
+    publicKey = crypto.createPublicKey({
+        key: fs.readFileSync(privateKeyFile), //generate public key from private key
+        format: 'pem',
+    });
+} else {
+    const keys = crypto.generateKeyPairSync('ed25519');
+    privateKey = keys.privateKey;
+    publicKey = keys.publicKey;
     fs.writeFileSync(
         privateKeyFile,
         privateKey.export({
@@ -17,15 +26,7 @@ if (!fs.existsSync(privateKeyFile)) {
             format: 'pem',
         })
     );
-}
-if (!fs.existsSync(publicKeyFile)) {
-    fs.writeFileSync(
-        publicKeyFile,
-        publicKey.export({
-            type: 'spki',
-            format: 'pem',
-        })
-    );
+    //not exporting the public key file since it's trivial to get it from the private key so let's save on some IO
 }
 
 export { privateKey, publicKey };


### PR DESCRIPTION
#### **What does this PR do?**

Fix keypair loading to not unnecessarily regenerate it on server start 

#### **How is this PR tested?**

Tested with creating a new user and seeing if the JWT successfully passes the middleware before and after server restart.

#### **Checklist**

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] My merge commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
