### PR TITLE
refactor: refactor rooms command to only use select menus

### DIFF
--- a/src/discord/commands/book.ts
+++ b/src/discord/commands/book.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, MessageEmbed, MessageActionRow, MessageSelectMenu, MessageButton, ButtonInteraction, SelectMenuInteraction, Message } from 'discord.js';
+import { CommandInteraction, MessageEmbed, MessageActionRow, MessageSelectMenu, MessageButton, SelectMenuInteraction, Message } from 'discord.js';
 import RoomModel, { Room } from '../../models/room.model';
 import SectionModel, { Section } from '../../models/section.model';
 import TimeblockModel from '../../models/timeBlock.model';
@@ -164,7 +164,7 @@ export default {
         },
     ],
 
-    async execute(interaction: CommandInteraction | ButtonInteraction, _roomId?: string, _sectionId?: string): Promise<void> {
+    async execute(interaction: CommandInteraction | SelectMenuInteraction, _roomId?: string, _sectionId?: string): Promise<void> {
         if (interaction.isCommand()) {
             await parseCommandOptions(interaction).then((response) => {
                 if (response === undefined) return;
@@ -268,6 +268,8 @@ export default {
                     default:
                         console.log('Selected Menu Not Found!');
                 }
+            } else {
+                menuInteraction.reply({ content: "This select menu isn't for you!", ephemeral: true });
             }
         });
     },


### PR DESCRIPTION
#### **What does this PR do?**

PR removes buttons to display sections of a room. An embed has a limit of 5 buttons per action line, and sections potentially have more than 5 sections. It is neater to use a select menu compared to a million buttons. 

#### **How is this PR tested?**

Tested by running the command. 

#### **Checklist**

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] My merge commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
